### PR TITLE
Retrieves Game Details Externally

### DIFF
--- a/.tina/__generated__/_graphql.json
+++ b/.tina/__generated__/_graphql.json
@@ -1143,92 +1143,6 @@
       "directives": [],
       "name": {
         "kind": "Name",
-        "value": "GameSectionsDetails"
-      },
-      "fields": [
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "dateReleased"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          }
-        },
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "averageRating"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          }
-        },
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "averagePlaytime"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          }
-        },
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "content"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          }
-        },
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "learnMoreLink"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "ObjectTypeDefinition",
-      "interfaces": [],
-      "directives": [],
-      "name": {
-        "kind": "Name",
         "value": "GameSectionsBacklog"
       },
       "fields": [
@@ -1347,13 +1261,6 @@
           "kind": "NamedType",
           "name": {
             "kind": "Name",
-            "value": "GameSectionsDetails"
-          }
-        },
-        {
-          "kind": "NamedType",
-          "name": {
-            "kind": "Name",
             "value": "GameSectionsBacklog"
           }
         },
@@ -1394,7 +1301,7 @@
           "kind": "FieldDefinition",
           "name": {
             "kind": "Name",
-            "value": "deck"
+            "value": "howLongToBeatId"
           },
           "arguments": [],
           "type": {
@@ -1994,85 +1901,6 @@
       "kind": "InputObjectTypeDefinition",
       "name": {
         "kind": "Name",
-        "value": "GameSectionsDetailsMutation"
-      },
-      "fields": [
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "dateReleased"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          }
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "averageRating"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          }
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "averagePlaytime"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          }
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "content"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          }
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "learnMoreLink"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "InputObjectTypeDefinition",
-      "name": {
-        "kind": "Name",
         "value": "GameSectionsBacklogMutation"
       },
       "fields": [
@@ -2182,20 +2010,6 @@
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "details"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "GameSectionsDetailsMutation"
-            }
-          }
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
             "value": "backlog"
           },
           "type": {
@@ -2247,7 +2061,7 @@
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "deck"
+            "value": "howLongToBeatId"
           },
           "type": {
             "kind": "NamedType",

--- a/.tina/__generated__/_lookup.json
+++ b/.tina/__generated__/_lookup.json
@@ -66,7 +66,6 @@
     "type": "GameSections",
     "resolveType": "unionData",
     "typeMap": {
-      "details": "GameSectionsDetails",
       "backlog": "GameSectionsBacklog",
       "review": "GameSectionsReview"
     }

--- a/.tina/__generated__/_schema.json
+++ b/.tina/__generated__/_schema.json
@@ -15,16 +15,12 @@
           ]
         },
         {
+          "name": "howLongToBeatId",
+          "label": "HowLongToBeat(tm) ID#",
           "type": "string",
-          "name": "deck",
-          "label": "Deck",
-          "isBody": true,
-          "ui": {
-            "component": "textarea"
-          },
           "namespace": [
             "game",
-            "deck"
+            "howLongToBeatId"
           ]
         },
         {
@@ -126,78 +122,6 @@
           "label": "Sections",
           "list": true,
           "templates": [
-            {
-              "name": "details",
-              "label": "Details",
-              "fields": [
-                {
-                  "name": "dateReleased",
-                  "label": "Released On",
-                  "type": "datetime",
-                  "ui": {
-                    "dateFormat": "MMM D, YYYY"
-                  },
-                  "namespace": [
-                    "game",
-                    "sections",
-                    "details",
-                    "dateReleased"
-                  ]
-                },
-                {
-                  "name": "averageRating",
-                  "label": "Avg Rating (out of 100)",
-                  "type": "string",
-                  "namespace": [
-                    "game",
-                    "sections",
-                    "details",
-                    "averageRating"
-                  ]
-                },
-                {
-                  "name": "averagePlaytime",
-                  "label": "Avg Playtime (in hours)",
-                  "type": "string",
-                  "namespace": [
-                    "game",
-                    "sections",
-                    "details",
-                    "averagePlaytime"
-                  ]
-                },
-                {
-                  "name": "content",
-                  "label": "Content",
-                  "type": "string",
-                  "ui": {
-                    "component": "textarea"
-                  },
-                  "namespace": [
-                    "game",
-                    "sections",
-                    "details",
-                    "content"
-                  ]
-                },
-                {
-                  "name": "learnMoreLink",
-                  "label": "Learn More Link",
-                  "type": "string",
-                  "namespace": [
-                    "game",
-                    "sections",
-                    "details",
-                    "learnMoreLink"
-                  ]
-                }
-              ],
-              "namespace": [
-                "game",
-                "sections",
-                "details"
-              ]
-            },
             {
               "name": "backlog",
               "label": "Backlog",

--- a/.tina/__generated__/config/schema.json
+++ b/.tina/__generated__/config/schema.json
@@ -11,13 +11,9 @@
           "label": "Name"
         },
         {
-          "type": "string",
-          "name": "deck",
-          "label": "Deck",
-          "isBody": true,
-          "ui": {
-            "component": "textarea"
-          }
+          "name": "howLongToBeatId",
+          "label": "HowLongToBeat(tm) ID#",
+          "type": "string"
         },
         {
           "name": "status",
@@ -95,43 +91,6 @@
           "label": "Sections",
           "list": true,
           "templates": [
-            {
-              "name": "details",
-              "label": "Details",
-              "fields": [
-                {
-                  "name": "dateReleased",
-                  "label": "Released On",
-                  "type": "datetime",
-                  "ui": {
-                    "dateFormat": "MMM D, YYYY"
-                  }
-                },
-                {
-                  "name": "averageRating",
-                  "label": "Avg Rating (out of 100)",
-                  "type": "string"
-                },
-                {
-                  "name": "averagePlaytime",
-                  "label": "Avg Playtime (in hours)",
-                  "type": "string"
-                },
-                {
-                  "name": "content",
-                  "label": "Content",
-                  "type": "string",
-                  "ui": {
-                    "component": "textarea"
-                  }
-                },
-                {
-                  "name": "learnMoreLink",
-                  "label": "Learn More Link",
-                  "type": "string"
-                }
-              ]
-            },
             {
               "name": "backlog",
               "label": "Backlog",

--- a/.tina/__generated__/schema.gql
+++ b/.tina/__generated__/schema.gql
@@ -80,14 +80,6 @@ type GameMeta {
   medium: String
 }
 
-type GameSectionsDetails {
-  dateReleased: String
-  averageRating: String
-  averagePlaytime: String
-  content: String
-  learnMoreLink: String
-}
-
 type GameSectionsBacklog {
   interest: String
   content: String
@@ -100,11 +92,11 @@ type GameSectionsReview {
   content: String
 }
 
-union GameSections = GameSectionsDetails | GameSectionsBacklog | GameSectionsReview
+union GameSections = GameSectionsBacklog | GameSectionsReview
 
 type Game {
   name: String
-  deck: String
+  howLongToBeatId: String
   status: String
   meta: GameMeta
   sections: [GameSections]
@@ -147,14 +139,6 @@ input GameMetaMutation {
   medium: String
 }
 
-input GameSectionsDetailsMutation {
-  dateReleased: String
-  averageRating: String
-  averagePlaytime: String
-  content: String
-  learnMoreLink: String
-}
-
 input GameSectionsBacklogMutation {
   interest: String
   content: String
@@ -168,14 +152,13 @@ input GameSectionsReviewMutation {
 }
 
 input GameSectionsMutation {
-  details: GameSectionsDetailsMutation
   backlog: GameSectionsBacklogMutation
   review: GameSectionsReviewMutation
 }
 
 input GameMutation {
   name: String
-  deck: String
+  howLongToBeatId: String
   status: String
   meta: GameMetaMutation
   sections: [GameSectionsMutation]

--- a/.tina/__generated__/types.ts
+++ b/.tina/__generated__/types.ts
@@ -147,15 +147,6 @@ export type GameMeta = {
   medium?: Maybe<Scalars['String']>;
 };
 
-export type GameSectionsDetails = {
-  __typename?: 'GameSectionsDetails';
-  dateReleased?: Maybe<Scalars['String']>;
-  averageRating?: Maybe<Scalars['String']>;
-  averagePlaytime?: Maybe<Scalars['String']>;
-  content?: Maybe<Scalars['String']>;
-  learnMoreLink?: Maybe<Scalars['String']>;
-};
-
 export type GameSectionsBacklog = {
   __typename?: 'GameSectionsBacklog';
   interest?: Maybe<Scalars['String']>;
@@ -170,12 +161,12 @@ export type GameSectionsReview = {
   content?: Maybe<Scalars['String']>;
 };
 
-export type GameSections = GameSectionsDetails | GameSectionsBacklog | GameSectionsReview;
+export type GameSections = GameSectionsBacklog | GameSectionsReview;
 
 export type Game = {
   __typename?: 'Game';
   name?: Maybe<Scalars['String']>;
-  deck?: Maybe<Scalars['String']>;
+  howLongToBeatId?: Maybe<Scalars['String']>;
   status?: Maybe<Scalars['String']>;
   meta?: Maybe<GameMeta>;
   sections?: Maybe<Array<Maybe<GameSections>>>;
@@ -242,14 +233,6 @@ export type GameMetaMutation = {
   medium?: Maybe<Scalars['String']>;
 };
 
-export type GameSectionsDetailsMutation = {
-  dateReleased?: Maybe<Scalars['String']>;
-  averageRating?: Maybe<Scalars['String']>;
-  averagePlaytime?: Maybe<Scalars['String']>;
-  content?: Maybe<Scalars['String']>;
-  learnMoreLink?: Maybe<Scalars['String']>;
-};
-
 export type GameSectionsBacklogMutation = {
   interest?: Maybe<Scalars['String']>;
   content?: Maybe<Scalars['String']>;
@@ -263,14 +246,13 @@ export type GameSectionsReviewMutation = {
 };
 
 export type GameSectionsMutation = {
-  details?: Maybe<GameSectionsDetailsMutation>;
   backlog?: Maybe<GameSectionsBacklogMutation>;
   review?: Maybe<GameSectionsReviewMutation>;
 };
 
 export type GameMutation = {
   name?: Maybe<Scalars['String']>;
-  deck?: Maybe<Scalars['String']>;
+  howLongToBeatId?: Maybe<Scalars['String']>;
   status?: Maybe<Scalars['String']>;
   meta?: Maybe<GameMetaMutation>;
   sections?: Maybe<Array<Maybe<GameSectionsMutation>>>;

--- a/.tina/schema.ts
+++ b/.tina/schema.ts
@@ -21,13 +21,9 @@ export default defineSchema({
           label: "Name",
         },
         {
+          name: "howLongToBeatId",
+          label: "HowLongToBeat(tm) ID#",
           type: "string",
-          name: "deck",
-          label: "Deck",
-          isBody: true,
-          ui: {
-            component: "textarea",
-          },
         },
         {
           name: "status",
@@ -66,43 +62,6 @@ export default defineSchema({
           label: "Sections",
           list: true,
           templates: [
-            {
-              name: "details",
-              label: "Details",
-              fields: [
-                {
-                  name: "dateReleased",
-                  label: "Released On",
-                  type: "datetime",
-                  ui: {
-                    dateFormat: "MMM D, YYYY",
-                  },
-                },
-                {
-                  name: "averageRating",
-                  label: "Avg Rating (out of 100)",
-                  type: "string",
-                },
-                {
-                  name: "averagePlaytime",
-                  label: "Avg Playtime (in hours)",
-                  type: "string",
-                },
-                {
-                  name: "content",
-                  label: "Content",
-                  type: "string",
-                  ui: {
-                    component: "textarea",
-                  },
-                },
-                {
-                  name: "learnMoreLink",
-                  label: "Learn More Link",
-                  type: "string",
-                },
-              ],
-            },
             {
               name: "backlog",
               label: "Backlog",

--- a/content/games/CodeVein.md
+++ b/content/games/CodeVein.md
@@ -1,29 +1,12 @@
 ---
 name: Code Vein
+howLongToBeatId: '46470'
 status: Playing
 meta:
   genre: Action
   platform: 'PC, Steam'
   medium: Digital
 sections:
-  - dateReleased: '2019-09-27T05:00:00.000Z'
-    averageRating: '76'
-    averagePlaytime: '25'
-    content: >-
-      In the not too distant future, a mysterious disaster has brought collapse
-      to the world as we know it. Towering skyscrapers, once symbols of
-      prosperity, are now lifeless graves of humanity’s past pierced by the
-      Thorns of Judgment. At the center of the destruction lies a hidden society
-      of Revenants called Vein. This final stronghold is where the remaining few
-      fight to survive, blessed with Gifts of power in exchange for their
-      memories and a thirst for blood. Give into the bloodlust fully and risk
-      becoming one of the Lost, fiendish ghouls devoid of any remaining
-      humanity. Wandering aimlessly in search of blood, the Lost will stop at
-      nothing to satisfy their hunger. Team up and embark on a journey to the
-      ends of hell to unlock your past and escape your living nightmare in CODE
-      VEIN.
-    learnMoreLink: 'https://www.giantbomb.com/code-vein/3030-59194/'
-    _template: details
   - interest: Weak
     content: >-
       As a big fan of the "Soulsborne" series, the idea of an "Anime" Dark Souls
@@ -36,4 +19,4 @@ sections:
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630353721/3120975-box_cv_gmwnir.png
 ---
-Code Vein is set in the not too distant future where a disaster has brought the world to ruin and vampire-like beings battle for dominance.
+

--- a/content/games/DarkCloud2.md
+++ b/content/games/DarkCloud2.md
@@ -1,20 +1,14 @@
 ---
 name: Dark Cloud 2
+howLongToBeatId: '2205'
 status: Finished
+meta:
+  genre: Role-Playing
+  platform: Playstation 4
+  medium: Digital
 sections:
-  - content: >-
-      Dark Cloud 2, also known as Dark Chronicle, was developed by Level-5 and
-      published by Sony. Just like its predecessor Dark Cloud, the game is a
-      randomly-generated dungeon crawler with town building and weapon synthesis
-      mechanics. New to the series is time-travel. The majority of the game is
-      set in the past, where the player will have to meet certain conditions in
-      order to restore the future to what it once was.
-    learnMoreLink: 'https://www.giantbomb.com/dark-cloud-2/3030-10007/'
-    dateReleased: '2003-02-17T06:00:00.000Z'
-    averageRating: '83'
-    averagePlaytime: '52'
-    _template: details
   - dateFinished: '2020-01-04T06:00:00.000Z'
+    stars: '5'
     playtime: '75'
     content: >-
       I originally bought this game in 2003 when it was released for the PS2
@@ -41,13 +35,8 @@ sections:
 
       I enjoyed my time with it; it's a very good game. When I was... 16-17,
       this would've been my dream game.
-    stars: '5'
     _template: review
-meta:
-  medium: Digital
-  platform: Playstation 4
-  genre: Role-Playing
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1629750583/games/boxart/2117020-box_dcloud2_ibss7i.png
 ---
-Control Max, a young inventor, and Monica, a warrior princess from the future, as they fight their way through dungeons and train rides to save the world.
+

--- a/content/games/DragonQuestBuilders2.md
+++ b/content/games/DragonQuestBuilders2.md
@@ -1,22 +1,12 @@
 ---
 name: Dragon Quest Builders 2
+howLongToBeatId: '64365'
 status: Playing
 meta:
   genre: Sandbox
   platform: 'PC, Xbox Game Pass'
   medium: Digital
 sections:
-  - dateReleased: '2019-07-12T05:00:00.000Z'
-    averageRating: '85'
-    averagePlaytime: '55'
-    content: >-
-      A sequel in the spin-off series Dragon Quest, Dragon Quest Builders 2
-      brings back the building and creation gameplay from the first game and
-      adds in a different narrative/design structure, introduces new tools and
-      features making construction simpler, new ways to travel around the maps,
-      and multiplayer.
-    learnMoreLink: 'https://www.giantbomb.com/dragon-quest-builders-2/3030-60667/'
-    _template: details
   - interest: Strong
     content: >-
       Ironically, I bought and have been slowly working through the first Dragon
@@ -29,4 +19,4 @@ sections:
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630016229/3104000-box_dqb2_eyo3h3.png
 ---
-The sequel to Square-Enix' world-building Dragon Quest game.
+

--- a/content/games/FinalFantasy7Remake.md
+++ b/content/games/FinalFantasy7Remake.md
@@ -1,22 +1,12 @@
 ---
 name: Final Fantasy VII Remake
+howLongToBeatId: '57686'
 status: Finished
 meta:
   genre: Action
   platform: Playstation 4
   medium: Digital
 sections:
-  - dateReleased: '2020-04-10T05:00:00.000Z'
-    averageRating: '87'
-    averagePlaytime: '33'
-    content: >-
-      What begins as a rebellion against an evil corporation becomes much more,
-      and what erupts goes beyond imagination. The story of this first,
-      standalone game in the Final Fantasy VII Remake project covers up to the
-      party's escape from Midgar and goes deeper into the events occurring in
-      the city than the original Final Fantasy VII.
-    learnMoreLink: 'https://www.giantbomb.com/final-fantasy-vii-remake/3030-49974/'
-    _template: details
   - dateFinished: '2020-04-15T05:00:00.000Z'
     stars: '5'
     playtime: '45'
@@ -41,4 +31,4 @@ sections:
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630015986/57686_Final_Fantasy_VII_Remake_xwt4zi.jpg
 ---
-Teased since the PlayStation 3's debut, Square Enix finally delivers a complete remake of the fan favorite Final Fantasy from 1997.
+

--- a/content/games/FinalFantasyXII.md
+++ b/content/games/FinalFantasyXII.md
@@ -6,26 +6,9 @@ meta:
   platform: Playstation 4
   medium: Digital
 sections:
-  - dateReleased: '2006-10-31T06:00:00.000Z'
-    averageRating: '83'
-    averagePlaytime: '61'
-    content: >-
-      Two years after the fall of Dalmasca, the citizens are without guidance
-      and direction. In the capital city of Rabanastre, the denizens gather and
-      await the introduction of Archadia's new consul. To Vaan, a young man
-      living on the streets of Rabanastre, the Empire is a hated enemy who took
-      the life of his brother, the only family he had left. In an effort to
-      exact revenge, Vaan hatches a plot to break into the palace and steal from
-      the occupying imperials. There, he gets more than he bargained for as he
-      runs into Princess Ashe, the sole surviving heir to the Dalmascan throne.
-      Together, the two will embark on an incredible journey through Ivalice,
-      tracing the mysteries behind the Archadian Empire's invasion. The choices
-      they make will determine the very fate of the world.
-    learnMoreLink: 'https://www.giantbomb.com/final-fantasy-xii-the-zodiac-age/3030-54121/'
-    _template: details
-  - dateFinished: '2020-05-10T05:00:00.000Z'
-    stars: '4'
-    playtime: '140'
+  - dateFinished: "2020-05-10T05:00:00.000Z"
+    stars: "4"
+    playtime: "140"
     content: >-
       Hot on the heels of getting the Platinum in Final Fantasy 7 Remake, I did
       not want to let go of my enjoyment of Final Fantasy.
@@ -49,4 +32,5 @@ sections:
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630091202/3124183-1203822419-packs_u7fkl8.jpg
 ---
+
 The Zodiac Age is a remake of 2006's Final Fantasy XII that includes a job system that was previously only available in the Japan-only "International" edition. The remake also includes various other additions and enhancements.

--- a/content/games/FinalFantasyXV.md
+++ b/content/games/FinalFantasyXV.md
@@ -6,23 +6,12 @@ meta:
   platform: Playstation 4
   medium: Digital
 sections:
-  - averageRating: '78'
-    averagePlaytime: '28'
-    content: >-
-      The only crystal left to the world lies in the Kingdom of Lucis. Upon
-      striking a peace with the garrison state of Niflheim, Lucis rejoices in
-      having at last brought the cold war to a close. Their celebrations,
-      however, are premature. Under the guise of amity, Niflheim dispels the
-      anti-armament runewall and launches a full-scale invasion of the kingdom.
-      The peaceful lives Crown Prince Noctis and his entourage once knew are
-      consumed by the flames of war as they struggle to mount a resistance.
-    learnMoreLink: 'https://www.giantbomb.com/final-fantasy-xv/3030-21006/'
-    _template: details
-  - dateFinished: '2017-01-01T06:00:00.000Z'
-    stars: '3'
+  - dateFinished: "2017-01-01T06:00:00.000Z"
+    stars: "3"
     content: All trophies!
     _template: review
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630354024/2903750-final_fantasy_xv_v3_qnz5vu.jpg
 ---
+
 The fifteenth entry in Square Enix's flagship RPG franchise, set in a world that mixes elements of modern technology with magic, a fantasy based on reality.

--- a/content/games/GravityRush.md
+++ b/content/games/GravityRush.md
@@ -6,27 +6,12 @@ meta:
   platform: Playstation 4
   medium: Digital
 sections:
-  - dateReleased: '2012-06-12T05:00:00.000Z'
-    averageRating: '78'
-    averagePlaytime: '10'
-    content: >-
-      Gravity Rush is a single player Action-Adventure game with RPG and
-      Platforming game elements that is specifically designed for PlayStation
-      Vita. Utilizing PS Vita specific functionality such as the gyro motion
-      sensor of the PS Vita, highly refined graphics and touch control
-      capabilities, and a rich storyline rendered in a crisp
-      comic/animation-like style, Gravity Rush provides an engrossing 3D
-      experience in which the usual laws of gravity cease to exist. Additional
-      features include: simple shoulder button-based controls for
-      gravity-altering move, varied enemy and boss battles, and beat-em-up
-      combat.
-    learnMoreLink: 'https://www.giantbomb.com/gravity-rush/3030-35617/'
-    _template: details
-  - dateFinished: '2017-01-01T06:00:00.000Z'
-    stars: '4'
+  - dateFinished: "2017-01-01T06:00:00.000Z"
+    stars: "4"
     content: All trophies!
     _template: review
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630354607/2160624-box_grush_vafkcd.png
 ---
+
 An open world action-adventure game in which players take control of Kat, an amnesiac who finds herself in a strange city with a black cat... and the power to manipulate gravity.

--- a/content/games/GravityRush2.md
+++ b/content/games/GravityRush2.md
@@ -6,18 +6,6 @@ meta:
   platform: Playstation 4
   medium: Digital
 sections:
-  - dateReleased: '2017-01-20T06:00:00.000Z'
-    averageRating: '78'
-    averagePlaytime: '20'
-    content: >-
-      Manipulate gravity and soar the skies in an open world. Another
-      mind-bending adventure awaits gravity queen Kat as a new danger emerges to
-      threaten the fabric of the universe itself. Still searching for clues
-      behind the mystery of her origin, and with the powerful Raven at her side,
-      Kat must master three unique gravity attack styles as she takes on enemies
-      and massive bosses.
-    learnMoreLink: 'https://www.giantbomb.com/gravity-rush-2/3030-43972/'
-    _template: details
   - interest: Strong
     content: >-
       I thoroughly enjoyed the first game and learning that the sequel was
@@ -26,4 +14,5 @@ sections:
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630354814/2931623-gravity_rush_2_v8_lghh7r.jpg
 ---
+
 A follow-up to one of Vita's most acclaimed original games.

--- a/content/games/HyruleWarriorsAgeOfCalamity.md
+++ b/content/games/HyruleWarriorsAgeOfCalamity.md
@@ -1,23 +1,11 @@
 ---
-name: 'Hyrule Warriors: Age of Calamity'
+name: "Hyrule Warriors: Age of Calamity"
 status: Playing
 meta:
   genre: Action
   platform: Nintendo Switch
   medium: Digital
 sections:
-  - dateReleased: 'Fri, 20 Nov 2020 06:00:00 GMT'
-    averageRating: '79'
-    averagePlaytime: '23'
-    content: >-
-      See Hyrule 100 years before The Legend of Zelda: Breath of the Wild and
-      experience the events of the Great Calamity. Join the struggle that
-      brought Hyrule to its knees. Learn more about Zelda, the four Champions,
-      the King of Hyrule and more through dramatic cutscenes as they try to save
-      the kingdom from Calamity. Hyrule Warriors: Age of Calamity is the only
-      way to firsthand see what happened 100 years ago.
-    learnMoreLink: 'https://www.giantbomb.com/hyrule-warriors-age-of-calamity/3030-80542/'
-    _template: details
   - interest: Strong
     content: >-
       I've put well over 500 hours into the first Hyrule Warriors.
@@ -29,4 +17,5 @@ sections:
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630428582/3241516-untitled-1_ac0nbb.png
 ---
+
 Hyrule Warriors: Age of Calamity is set 100 years prior to the events of Breath of the Wild.

--- a/content/games/MonsterHunterStories2.md
+++ b/content/games/MonsterHunterStories2.md
@@ -1,28 +1,11 @@
 ---
-name: 'Monster Hunter Stories 2: Wings of Ruin'
+name: "Monster Hunter Stories 2: Wings of Ruin"
 status: Playing
 meta:
   genre: Role-Playing
   platform: Nintendo Switch
   medium: Digital
 sections:
-  - dateReleased: '2021-07-09T05:00:00.000Z'
-    averageRating: '80'
-    averagePlaytime: '37'
-    content: >-
-      A new adventure awaits you in this second installment of the turn-based
-      RPG series set in the world of Monster Hunter! Become a Rider and form
-      bonds with friendly monsters known as Monsties to fight alongside them as
-      you take part in an epic story. You play as the grandson of Red, a
-      legendary Rider. The story begins with a fateful encounter with Ena, a
-      Wyverian girl who has been entrusted with an egg with the potential to
-      hatch into a legendary Rathalos which could wreak havoc if awakened to its
-      destructive power. Embark on a journey which will test the bonds of
-      friendship in a changing world, and discover the truth behind the legends
-      of old.
-    learnMoreLink: >-
-      https://www.giantbomb.com/monster-hunter-stories-2-wings-of-ruin/3030-80645/
-    _template: details
   - interest: Strong
     content: >-
       A delightful combination of Monster Hunter and Pokemon?  Two of my
@@ -34,4 +17,5 @@ sections:
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630101431/Monster_Hunter_Stories_2_Wings_of_Ruin_jtpoqq.jpg
 ---
+
 The second entry in the Monster Hunter spin-off series Monster Hunter Stories.

--- a/content/games/MonsterHunterWorld.md
+++ b/content/games/MonsterHunterWorld.md
@@ -1,25 +1,14 @@
 ---
-name: 'Monster Hunter: World'
+name: "Monster Hunter: World"
 status: Finished
 meta:
   genre: Action
   platform: Playstation 4
   medium: Digital
 sections:
-  - dateReleased: '2018-01-26T06:00:00.000Z'
-    averageRating: '84'
-    averagePlaytime: '47'
-    content: >-
-      Welcome to a new world! Take on the role of a hunter and slay ferocious
-      monsters in a living, breathing ecosystem where you can use the landscape
-      and its diverse inhabitants to get the upper hand. Hunt alone or in co-op
-      with up to three other players, and use materials collected from fallen
-      foes to craft new gear and take on even bigger, badder beasts!
-    learnMoreLink: 'https://www.giantbomb.com/monster-hunter-world/3030-59924/'
-    _template: details
-  - dateFinished: '2018-02-15T06:00:00.000Z'
-    stars: '5'
-    playtime: '300'
+  - dateFinished: "2018-02-15T06:00:00.000Z"
+    stars: "5"
+    playtime: "300"
     content: >-
       As a fan of the genre, this is the pinnacle - setting the bar high for the
       other "MonHun Clones". 
@@ -30,4 +19,5 @@ sections:
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630092940/2996112-monster_hunter_-_world_v1_zbglxz.jpg
 ---
+
 The fifth primary title in the Monster Hunter franchise features much larger maps, seamless transitions between zones in the map and four-player online co-op. It allows players from Japan and western countries to play together for the first time in the series.

--- a/content/games/NierReplicant.md
+++ b/content/games/NierReplicant.md
@@ -2,16 +2,6 @@
 name: NieR Replicant ver. 1.22474487139
 status: Playing
 sections:
-  - content: >-
-      Set in a post-apocalyptic world, NieR Replicant ver.1.22474487139 is puts
-      you in the role of the titular Nier, a young man on a quest to cure his
-      sister Yonah of a deadly disease. What they discover will make them
-      question everything they thought they knew.
-    learnMoreLink: 'https://www.giantbomb.com/nier-replicant/3030-29650/'
-    dateReleased: '2021-04-23T05:00:00.000Z'
-    averageRating: '85'
-    averagePlaytime: '19'
-    _template: details
   - interest: Strong
     content: >-
       I played NieR Automata through completion, 100%, all **26 endings**. 
@@ -28,4 +18,5 @@ meta:
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630015100/3286238-main_fmoe57.jpg
 ---
+
 NieR Replicant is an alternate version of NieR released exclusively in Japan for the PlayStation 3. A remake was developed for PlayStation 4, PC, and Xbox One and released in 2021.

--- a/content/games/OdinSphereLeifthrasir.md
+++ b/content/games/OdinSphereLeifthrasir.md
@@ -1,21 +1,16 @@
 ---
-name: 'Odin Sphere: Leifthrasir'
+name: "Odin Sphere: Leifthrasir"
 status: Finished
 meta:
   genre: Action
   platform: Playstation 4
   medium: Digital
 sections:
-  - dateReleased: '2016-06-07T05:00:00.000Z'
-    averageRating: '83'
-    averagePlaytime: '30'
-    content: Change the fate of the world when the end of days draws near!
-    learnMoreLink: 'https://www.giantbomb.com/odin-sphere-leifthrasir/3030-50389/'
-    _template: details
-  - dateFinished: '2017-01-01T06:00:00.000Z'
-    stars: '4'
+  - dateFinished: "2017-01-01T06:00:00.000Z"
+    stars: "4"
     _template: review
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630356233/2856056-main_qzz01t.png
 ---
+
 An HD remaster of Odin Sphere containing reworked gameplay and additional content.

--- a/content/games/ParadiseKiller.md
+++ b/content/games/ParadiseKiller.md
@@ -2,16 +2,6 @@
 name: Paradise Killer
 status: Backlog
 sections:
-  - content: >-
-      Paradise Island, a world outside reality. There’s been a murder that only
-      "investigation freak" Lady Love Dies can solve. Gather evidence and
-      interrogate suspects in this open world adventure. You can accuse anyone,
-      but you’ll have to prove your case in trial to convict. It’s up to you to
-      decide who’s guilty.
-    learnMoreLink: 'https://www.giantbomb.com/paradise-killer/3030-77201/'
-    averageRating: '86'
-    averagePlaytime: '12'
-    _template: details
   - interest: Strong
     content: >-
       This title sits in the same pantheon as other games like "The Outer Wilds"
@@ -20,9 +10,10 @@ sections:
     _template: backlog
 meta:
   medium: Digital
-  platform: 'PC, Steam'
+  platform: "PC, Steam"
   genre: Adventure
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630007112/3167742-paradisekiller_cfecyk.jpg
 ---
+
 A first-person open world whodunnit where players investigate a murder-mystery as formerly exiled investigator Lady Love Dies.

--- a/content/games/Persona5Strikers.md
+++ b/content/games/Persona5Strikers.md
@@ -1,20 +1,12 @@
 ---
 name: Persona 5 Strikers
+howLongToBeatId: '72069'
 status: Finished
 meta:
   genre: Action
   platform: Playstation 4
   medium: Digital
 sections:
-  - dateReleased: '2021-02-23T06:00:00.000Z'
-    averageRating: '84'
-    averagePlaytime: '35'
-    content: >-
-      Four months after the events of Persona 5, the Phantom Thieves meet up for
-      summer vacation, only to be caught up in another adventure as many people
-      across Japan start to exhibit strange behavior related to the Metaverse.
-    learnMoreLink: 'https://www.giantbomb.com/persona-5-strikers/3030-73123/'
-    _template: details
   - dateFinished: '2021-03-11T06:00:00.000Z'
     stars: '5'
     playtime: '100'
@@ -26,4 +18,4 @@ sections:
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630015809/3273092-screenshot2021-02-14at8.20.01pm_flvslk.png
 ---
-A sequel to Persona 5 storyline with a real-time Musou-esque hack-and-slash combat.
+

--- a/content/games/ResidentEvil6.md
+++ b/content/games/ResidentEvil6.md
@@ -3,24 +3,9 @@ name: Resident Evil 6
 status: Playing
 meta:
   genre: Action
-  platform: 'PC, Steam'
+  platform: "PC, Steam"
   medium: Digital
 sections:
-  - dateReleased: '2012-10-02T05:00:00.000Z'
-    averageRating: '65'
-    averagePlaytime: '21'
-    content: >-
-      Resident Evil 6 is a Survival-Horror game that continues the struggle
-      against the series' signature zombie inducing bio-terror, while raising
-      the bar with all new game functionality. Players enjoy a diverse play
-      experience, highlighted by the ability to select between three scenarios
-      featuring multiple characters and intertwined storylines. Within these
-      scenarios both stories and action cross paths. Additional features include
-      zombies as well as new enemies, upgradable firepower and characters,
-      vehicle based options, the mini-game based Mercenaries mode, and
-      single-player and co-op play options.
-    learnMoreLink: 'https://www.giantbomb.com/resident-evil-6/3030-37273/'
-    _template: details
   - interest: Strong
     content: >-
       Resident Evil 6 remains a blank space in my knowledge of the core series
@@ -34,4 +19,5 @@ sections:
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630353310/2566466-re6clean_bksakz.jpg
 ---
+
 The technically eighth entry in the popular horror series features the return of leading protagonists Leon S. Kennedy and Chris Redfield, along with new character Jake Muller, to combat against the latest B.O.W. manufacturer Neo-Umbrella.

--- a/content/games/ResidentEvilRevelations.md
+++ b/content/games/ResidentEvilRevelations.md
@@ -1,23 +1,16 @@
 ---
-name: 'Resident Evil: Revelations'
+name: "Resident Evil: Revelations"
 status: Finished
 meta:
   genre: Action
-  platform: 'PC, Steam'
+  platform: "PC, Steam"
   medium: Digital
 sections:
-  - dateReleased: '2012-02-07T06:00:00.000Z'
-    averageRating: '75'
-    averagePlaytime: '8'
-    content: >-
-      Survive a ghost ship and rediscover survival-horror in the campaign
-      (single player) or Raid Mode (co-op).
-    learnMoreLink: 'https://www.giantbomb.com/resident-evil-revelations/3030-31737/'
-    _template: details
-  - dateFinished: '2017-02-01T06:00:00.000Z'
-    stars: '3'
+  - dateFinished: "2017-02-01T06:00:00.000Z"
+    stars: "3"
     _template: review
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630358023/2484600-revelaitons_be05dh.jpg
 ---
+
 Resident Evil: Revelations is a full, story-driven Resident Evil title in which Chris Redfield and Jill Valentine split up to investigate a new conspiracy, with new partners Parker and Jessica.

--- a/content/games/Superhot.md
+++ b/content/games/Superhot.md
@@ -3,23 +3,14 @@ name: Superhot
 status: Finished
 meta:
   genre: Shooter
-  platform: 'PC, Steam'
+  platform: "PC, Steam"
   medium: Digital
 sections:
-  - averageRating: '78'
-    averagePlaytime: '2'
-    content: >-
-      Blurring the lines between cautious strategy and unbridled mayhem,
-      SUPERHOT is the FPS in which time moves only when you move. No
-      regenerating health bars. No conveniently placed ammo drops. It's just
-      you, outnumbered and outgunned, grabbing the weapons of fallen enemies to
-      shoot, slice, and maneuver through a hurricane of slow-motion bullets.
-    learnMoreLink: 'https://www.giantbomb.com/superhot/3030-43663/'
-    _template: details
-  - dateFinished: '2017-01-01T06:00:00.000Z'
-    stars: '5'
+  - dateFinished: "2017-01-01T06:00:00.000Z"
+    stars: "5"
     _template: review
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630354447/2949244-box_shot_i1rmat.png
 ---
+
 A puzzling first-person shooter in which time only progresses when the player moves.

--- a/content/games/TokyoJungle.md
+++ b/content/games/TokyoJungle.md
@@ -6,29 +6,11 @@ meta:
   platform: Playstation 3
   medium: Digital
 sections:
-  - averageRating: '72'
-    averagePlaytime: '15'
-    content: >-
-      Humans disappeared from Tokyo all of a sudden, leaving the animals to fend
-      for themselves. Play the game as various animals in this apocalyptic
-      scene. Learn to hunt, gather, and mark territory.
-
-
-      But survival isn't quite so simple. There might be poison in certain food,
-      and your player animal might be infected by other animals. Watch out for
-      their health as you create your home out of the rubble. The climate and
-      the temperature affects your animals as well. Beware of the rotten food in
-      the summer and the rains damaging your den.
-
-
-      There are many ways to survive, but only a few can. Become one of them in
-      Tokyo Jungle.
-    learnMoreLink: 'https://www.giantbomb.com/tokyo-jungle/3030-32532/'
-    _template: details
-  - dateFinished: '2017-02-01T06:00:00.000Z'
-    stars: '3'
+  - dateFinished: "2017-02-01T06:00:00.000Z"
+    stars: "3"
     _template: review
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630356802/2329203-box_tj_juoztv.png
 ---
+
 An action game set in post-apocalyptic Japan where the human race has inexplicably disappeared, leaving wild animals to reclaim the planet.

--- a/content/games/WatchDogs2.md
+++ b/content/games/WatchDogs2.md
@@ -6,19 +6,11 @@ meta:
   platform: Playstation 4
   medium: Digital
 sections:
-  - dateReleased: '2016-11-15T06:00:00.000Z'
-    averageRating: '76'
-    averagePlaytime: '19'
-    content: >-
-      Welcome to San Francisco. Play as Marcus, a brilliant young hacker, and
-      join the most notorious hacker group, DedSec. Your objective: execute the
-      biggest hack in history.
-    learnMoreLink: 'https://www.giantbomb.com/watch-dogs-2/3030-54066/'
-    _template: details
-  - dateFinished: '2017-01-01T06:00:00.000Z'
-    stars: '4'
+  - dateFinished: "2017-01-01T06:00:00.000Z"
+    stars: "4"
     _template: review
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630355364/2897495-watch_dogs_2_v1_cf4o4a.jpg
 ---
+
 The sequel to Watch Dogs moves to San Francisco with a new protagonist.

--- a/content/games/YookaLayleeAndTheImpossibleLair.md
+++ b/content/games/YookaLayleeAndTheImpossibleLair.md
@@ -3,19 +3,9 @@ name: Yooka-Laylee and the Impossible Lair
 status: Backlog
 meta:
   genre: Platformer
-  platform: 'PC, Epic'
+  platform: "PC, Epic"
   medium: Digital
 sections:
-  - dateReleased: '2019-10-08T05:00:00.000Z'
-    averageRating: '76'
-    averagePlaytime: '13'
-    content: >-
-      Yooka-Laylee and the Impossible Lair is a brand-new platform adventure
-      from some of the key creative talent behind 'Donkey Kong Country'. As the
-      colourful buddy duo you must tackle a series of stunning, 2.5D levels and
-      explore a puzzling 3D Overworld rich with secrets and surprises!
-    learnMoreLink: 'https://www.giantbomb.com/yooka-laylee-and-the-impossible-lair/3030-73741/'
-    _template: details
   - interest: Weak
     content: >-
       While I did not play the first Yooka-Laylee, I am slightly more interested
@@ -25,4 +15,5 @@ sections:
 boxart: >-
   http://res.cloudinary.com/forestry-chris/image/upload/v1630099452/3124950-box_ylstil_dmxtfb.png
 ---
+
 The sequel to Yooka-Laylee incorporates 2.5D platforming as well as returning to the 3D realm.

--- a/hooks/game.ts
+++ b/hooks/game.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+interface ExternalInfo {
+  id: string;
+  dateReleased?: string;
+  averagePlaytime?: number;
+  averageRating?: number;
+  summary?: string;
+  learnMoreLink?: string;
+  genre?: string;
+}
+
+export const useExternalInfo = (id: string) => {
+  const [info, setInfo] = useState<ExternalInfo | undefined>(undefined);
+
+  useEffect(() => {
+    const fetchInfo = async () => {
+      const response = await fetch(`/api/game/${id}`);
+      const info = await response.json();
+
+      setInfo(info);
+    };
+
+    if (id) {
+      fetchInfo();
+    }
+  }, [id]);
+
+  return info;
+};

--- a/lib/game.ts
+++ b/lib/game.ts
@@ -7,17 +7,10 @@ export const getGame = async (filename: string) => {
         getGameDocument(relativePath: $relativePath) {
           data {
             name
-            deck
+            howLongToBeatId
             status
             sections {
               __typename
-              ... on GameSectionsDetails {
-                content
-                learnMoreLink
-                dateReleased
-                averagePlaytime
-                averageRating
-              }
               ... on GameSectionsBacklog {
                 content
                 interest
@@ -61,10 +54,6 @@ export const getGames = async () => {
                 status
                 sections {
                   __typename
-                  ... on GameSectionsDetails {
-                    averageRating
-                    averagePlaytime
-                  }
                   ... on GameSectionsBacklog {
                     interest
                   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "marked": "^3.0.1",
     "next": "latest",
     "next-tinacms-cloudinary": "^3.2.3",
+    "node-html-parser": "^4.1.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remark": "13.0.0",

--- a/pages/api/game/[id].ts
+++ b/pages/api/game/[id].ts
@@ -1,0 +1,72 @@
+import { parse } from "node-html-parser";
+import { GENRES } from "../../../.tina/constants";
+
+export default async function handler(req, res) {
+  try {
+    const { id } = req.query;
+    const response = await fetch(`https://howlongtobeat.com/game?id=${id}`);
+    const html = await response.text();
+    const document = parse(html);
+
+    /**
+     * Genre
+     */
+    const genresEl = Array.from(
+      document.querySelectorAll("div.profile_info.medium")
+    ).find((el) => RegExp(/^Genres:/).test(el.textContent.trim()));
+    const genres = genresEl.textContent
+      .replace(/(Genres:|\n|\r)/gm, "")
+      .trim()
+      .split(", ");
+    const genre = GENRES.find((G) => genres.includes(G));
+
+    /**
+     * Date Released
+     */
+    const dateReleasedEl = Array.from(
+      document.querySelectorAll("div.profile_info")
+    ).find((el) => RegExp(/^NA:/).test(el.textContent.trim()));
+    const dateReleased = dateReleasedEl.textContent.trim().replace("NA: ", "");
+
+    /**
+     * Average Playtime
+     */
+    const averagePlaytimeEl = document.querySelector(
+      ".game_times ul li:nth-child(1) div"
+    );
+    const averagePlaytime = parseInt(averagePlaytimeEl.innerText);
+
+    /**
+     * Average Rating
+     */
+    const averageRatingEl = document.querySelector(
+      ".game_chart:nth-child(1) > h5"
+    );
+    const averageRating = parseInt(averageRatingEl.innerText);
+
+    /** Summary */
+    const summaryEl = document.querySelector(".profile_info.large");
+    const summary = `${summaryEl.innerHTML
+      .trim()
+      .replace(/<(.|\r|\n)*?>/g, "")
+      .replace("...Read More", "")}`;
+
+    /**
+     * Learn More Link
+     */
+    const learnMoreLink = `https://howlongtobeat.com/game?id=${id}`;
+
+    return res.status(200).json({
+      id,
+      dateReleased,
+      averagePlaytime,
+      averageRating,
+      summary,
+      learnMoreLink,
+      genre,
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(error.status || 500).end(error.message);
+  }
+}

--- a/pages/backlog/index.js
+++ b/pages/backlog/index.js
@@ -55,28 +55,16 @@ const BacklogList = (props) => {
    * Loops through all games, filtering for Playing and Backlog
    */
   const filterGames = [];
-  let totalAveragePlaytime = 0;
 
   games.forEach((game) => {
     const status = game.node.data.status;
     if (status === STATUS_PLAYING || status === STATUS_BACKLOG) {
-      const sectionDetails = game.node.data.sections?.filter(
-        (section) => section.__typename === "GameSectionsDetails"
-      );
       const sectionBacklog = game.node.data.sections?.filter(
         (section) => section.__typename === "GameSectionsBacklog"
       );
 
-      if (sectionDetails && sectionDetails.length > 0) {
-        const averagePlaytime = parseInt(sectionDetails[0].averagePlaytime);
-        if (averagePlaytime !== "NaN") {
-          totalAveragePlaytime += averagePlaytime;
-        }
-      }
-
       filterGames.push({
         ...game,
-        details: sectionDetails ? sectionDetails[0] : {},
         backlog: sectionBacklog ? sectionBacklog[0] : {},
       });
       return;
@@ -131,17 +119,12 @@ const BacklogList = (props) => {
             </h1>
           </div>
 
-          <dl className="mx-auto mt-5 grid grid-cols-1 sm:grid-cols-4 gap-4">
+          <dl className="mx-auto mt-5 grid grid-cols-1 sm:grid-cols-3 gap-4">
             <Stat
               className="sm:col-start-2"
               name="Total"
               stat={sortedGames.length}
               Icon={ArchiveIcon}
-            />
-            <Stat
-              name="Playtime"
-              stat={`${totalAveragePlaytime} Hrs`}
-              Icon={ClockIcon}
             />
           </dl>
           <div className="mt-8 flex flex-col">
@@ -175,29 +158,11 @@ const BacklogList = (props) => {
                         >
                           Genre
                         </th>
-                        <th
-                          scope="col"
-                          className="w-1/6 px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                        >
-                          Avg Rating
-                        </th>
-                        <th
-                          scope="col"
-                          className="w-1/6 px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                        >
-                          Avg Playtime
-                        </th>
                       </tr>
                     </thead>
                     <tbody>
                       {sortedGames.map(
-                        ({ node: { sys, data }, details, backlog }, idx) => {
-                          const starsNumber = countStars(
-                            parseInt(details.averageRating)
-                          );
-                          const starString = getStarString(starsNumber);
-                          const starColor = getStarColor(starsNumber);
-
+                        ({ node: { sys, data }, backlog }, idx) => {
                           return (
                             <tr
                               key={data.name}
@@ -232,18 +197,6 @@ const BacklogList = (props) => {
                               </td>
                               <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                                 {data?.meta?.genre && <>{data.meta.genre}</>}
-                              </td>
-                              <td
-                                className={`px-6 py-4 whitespace-nowrap text-sm font-medium ${
-                                  starColor || "text-gray-900"
-                                }`}
-                              >
-                                {details.averageRating ? starString : ""}
-                              </td>
-                              <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                                {details.averagePlaytime
-                                  ? `${details.averagePlaytime} Hrs`
-                                  : ""}
                               </td>
                             </tr>
                           );

--- a/pages/game/[filename].tsx
+++ b/pages/game/[filename].tsx
@@ -1,11 +1,10 @@
-import { useState, useEffect } from "react";
-
 import Head from "next/head";
 import { staticRequest, gql } from "tinacms";
 import { CameraIcon } from "@heroicons/react/solid";
 
+import { useExternalInfo } from "../../hooks/game";
 import { getGame } from "../../lib/game";
-import MarkedContent from "../../components/MarkedContent";
+
 import Navigation from "../../components/Navigation";
 
 import GamePageTags from "./components/GamePageTags";
@@ -19,7 +18,9 @@ const GamePage = (props) => {
       getGameDocument: { data: game },
     },
   } = props;
-  const { name, deck, status, sections, meta, boxart } = game;
+  const { name, howLongToBeatId, status, sections, meta, boxart } = game;
+
+  const external = useExternalInfo(howLongToBeatId);
 
   return (
     <>
@@ -40,7 +41,7 @@ const GamePage = (props) => {
               </h3>
               <GamePageTags
                 status={status}
-                genre={meta?.genre}
+                genre={meta?.genre || external?.genre}
                 medium={meta?.medium}
                 platform={meta?.platform}
               />
@@ -104,27 +105,21 @@ const GamePage = (props) => {
                 )}
               </div>
             </div>
-            <div className="mt-8 lg:mt-0">
-              <div className="text-base max-w-prose mx-auto lg:max-w-none">
-                <MarkedContent
-                  className="text-lg text-gray-500"
-                  content={deck}
-                ></MarkedContent>
-              </div>
-
+            <div>
+              {external && (
+                <GamePageDetails
+                  dateReleased={external?.dateReleased}
+                  averageRating={external?.averageRating}
+                  averagePlaytime={external?.averagePlaytime}
+                  summary={external?.summary}
+                  learnMoreLink={external?.learnMoreLink}
+                />
+              )}
               {sections &&
                 sections.map((section) => {
                   if (section.__typename === "GameSectionsReview") {
                     return (
                       <GamePageReview
-                        key={`${name}.${section.__typename}`}
-                        {...section}
-                      />
-                    );
-                  }
-                  if (section.__typename === "GameSectionsDetails") {
-                    return (
-                      <GamePageDetails
                         key={`${name}.${section.__typename}`}
                         {...section}
                       />

--- a/pages/game/components/GamePageDetails.tsx
+++ b/pages/game/components/GamePageDetails.tsx
@@ -4,15 +4,15 @@ import Stat from "../../../components/Stat";
 import RatingStat from "./RatingStat";
 
 interface Props {
-  content: string;
+  summary: string;
   learnMoreLink?: string;
   dateReleased?: string;
-  averageRating?: string;
-  averagePlaytime?: string;
+  averageRating?: number;
+  averagePlaytime?: number;
 }
 
 const GamePageDetails: React.FC<Props> = ({
-  content,
+  summary,
   learnMoreLink,
   dateReleased,
   averageRating,
@@ -29,7 +29,7 @@ const GamePageDetails: React.FC<Props> = ({
 
   return (
     <>
-      <div className="mt-5 prose prose-indigo text-gray-500 mx-auto lg:max-w-none lg:row-start-1 lg:col-start-1">
+      <div className="mt-0 prose prose-indigo text-gray-500 mx-auto lg:max-w-none lg:row-start-1 lg:col-start-1">
         <h2>Details</h2>
       </div>
       {localDateReleased && (
@@ -38,10 +38,7 @@ const GamePageDetails: React.FC<Props> = ({
       {(averageRating || averagePlaytime) && (
         <dl className="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-2">
           {averageRating && (
-            <RatingStat
-              name="Average Rating"
-              rating={parseInt(averageRating)}
-            />
+            <RatingStat name="Average Rating" rating={averageRating} />
           )}
           {averagePlaytime && (
             <Stat
@@ -53,7 +50,7 @@ const GamePageDetails: React.FC<Props> = ({
         </dl>
       )}
       <div className="mt-5 prose prose-indigo text-gray-500 mx-auto lg:max-w-none lg:row-start-1 lg:col-start-1">
-        <MarkedContent className="text-justify" content={content} />
+        <MarkedContent className="text-justify" content={summary} />
       </div>
       {learnMoreLink && (
         <div className="-mt-5 text-right">

--- a/pages/year/index.js
+++ b/pages/year/index.js
@@ -68,9 +68,6 @@ const YearsList = (props) => {
     const status = game.node.data.status;
     if (status === STATUS_FINISHED) {
       try {
-        const sectionDetails = game.node.data.sections?.filter(
-          (section) => section.__typename === "GameSectionsDetails"
-        );
         const sectionReview = game.node.data.sections?.filter(
           (section) => section.__typename === "GameSectionsReview"
         );
@@ -81,8 +78,7 @@ const YearsList = (props) => {
           gamesByYear[yearFinished] = { games: [], totalPlaytime: 0 };
         }
 
-        const playtime =
-          sectionReview[0].playtime || sectionDetails[0].averagePlaytime || 0;
+        const playtime = sectionReview[0].playtime || 0;
         if (!Number.isNaN(parseInt(playtime))) {
           gamesByYear[yearFinished].totalPlaytime += parseInt(playtime);
         }
@@ -152,7 +148,7 @@ const YearsList = (props) => {
                   <Stat name="Total" stat={games.length} Icon={ArchiveIcon} />
                   <Stat
                     name="Playtime"
-                    stat={`${totalPlaytime} Hrs`}
+                    stat={totalPlaytime ? `${totalPlaytime} Hrs` : "???"}
                     Icon={ClockIcon}
                   />
                 </dl>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3541,6 +3541,17 @@ css-select@^2.0.0:
     domutils "^1.7.0"
     nth-check "^1.0.2"
 
+css-select@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.1.3.tgz#a70440f70317f2669118ad74ff105e65849c7067"
+  integrity sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^5.0.0"
+    domhandler "^4.2.0"
+    domutils "^2.6.0"
+    nth-check "^2.0.0"
+
 css-to-react-native@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
@@ -3575,6 +3586,11 @@ css-what@^3.2.1:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
   integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
+
+css-what@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
+  integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
 
 css.escape@1.5.1, css.escape@^1.5.0:
   version "1.5.1"
@@ -3960,6 +3976,15 @@ domutils@^2.0.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.7.0.tgz#8ebaf0c41ebafcf55b0b72ec31c56323712c5442"
   integrity sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
+
+domutils@^2.6.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
   dependencies:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
@@ -6678,6 +6703,14 @@ node-html-parser@1.4.9:
   dependencies:
     he "1.2.0"
 
+node-html-parser@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-4.1.5.tgz#e3ff5b39a098e70de3629c9c79c4e29a3fa5f062"
+  integrity sha512-NLgqUXtftqnBqIjlRjYSaApaqE7TTxfTiH4VqKCjdUJKFOtUzRwney83EHz2qYc0XoxXAkYdmLjENCuZHvsIFg==
+  dependencies:
+    css-select "^4.1.3"
+    he "1.2.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -6765,6 +6798,13 @@ nth-check@^1.0.2:
   integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
   dependencies:
     boolbase "~1.0.0"
+
+nth-check@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
+  integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
+  dependencies:
+    boolbase "^1.0.0"
 
 nullthrows@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
For the most part, I was copying and pasting details from the website "How Long To Beat".

I began to wonder if I could engineer a way to have the website retrieve those details for itself based on an ID I provided.

I created a hook and an API endpoint and reworked a lot of the structure to account for the now missing "Details" section which is no longer necessary.

Unfortunately, this has resulted in removing some columns/metadata from the lists, as well.

But given that this change will _significantly_ increase the speed at which I can add games, I am fine with that trade.